### PR TITLE
Fix proxy

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+2019-11-06  Kirit Saelensminde  <kirit@felspar.com>
+ Add a reverse proxy view that allows for changes in request and response.
+
 2019-08-26  Tle Ekkul  <e.aryuth@gmail.com>
  Add Fost-Request-ID in every requests and response
 

--- a/Cpp/CMakeLists.txt
+++ b/Cpp/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_subdirectory(fost-urlhandler)
+add_subdirectory(fost-urlhandler-test)
 add_subdirectory(fost-webserver)
 add_subdirectory(fost-webtestrunner)

--- a/Cpp/fost-urlhandler-test/CMakeLists.txt
+++ b/Cpp/fost-urlhandler-test/CMakeLists.txt
@@ -1,0 +1,7 @@
+if(TARGET stress)
+    add_library(fost-urlhandler-test STATIC EXCLUDE_FROM_ALL
+            web-proxy.cpp
+        )
+    target_link_libraries(fost-urlhandler-test fost-urlhandler)
+    stress_test(fost-urlhandler-test)
+endif()

--- a/Cpp/fost-urlhandler-test/web-proxy.cpp
+++ b/Cpp/fost-urlhandler-test/web-proxy.cpp
@@ -6,19 +6,50 @@
  */
 
 
+#include <fost/insert>
 #include <fost/urlhandler>
 #include <fost/test>
+
+
+namespace {
+    auto proxy_config(f5::u8view const upstream) {
+        fostlib::json conf;
+        insert(conf, "view", "fost.proxy.transparent");
+        insert(conf, "configuration", "base", upstream);
+        return conf;
+    }
+}
 
 
 FSL_TEST_SUITE(web_proxy);
 
 
 /// Connect to an upstream server over HTTP
-FSL_TEST_FUNCTION(http) {}
+FSL_TEST_FUNCTION(http) {
+    fostlib::http::server::request req;
+    req.headers().add("Host", "neverssl.com");
+    auto const config = proxy_config("http://neverssl.com/");
+    auto const [response, status] = fostlib::urlhandler::view::execute(
+            config, "/", req, fostlib::host{"neverssl.com"});
+    FSL_CHECK_EQ(status, 200);
+    FSL_CHECK(
+            fostlib::string{response->body_as_string()}.find("NeverSSL")
+            != fostlib::string::npos);
+}
 
 
 /// Connect to an upstream server using TLS
-FSL_TEST_FUNCTION(https) {}
+FSL_TEST_FUNCTION(https) {
+    fostlib::http::server::request req;
+    req.headers().add("Host", "sha256.badssl.com");
+    auto const config = proxy_config("https://sha256.badssl.com/");
+    auto const [response, status] = fostlib::urlhandler::view::execute(
+            config, "/", req, fostlib::host{"sha256.badssl.com"});
+    FSL_CHECK_EQ(status, 200);
+    FSL_CHECK(
+            fostlib::string{response->body_as_string()}.find("sha256")
+            != fostlib::string::npos);
+}
 
 
 /// Connect to an upstream server where the host header

--- a/Cpp/fost-urlhandler-test/web-proxy.cpp
+++ b/Cpp/fost-urlhandler-test/web-proxy.cpp
@@ -1,5 +1,5 @@
 /**
-    Copyright 2012-2019 Red Anchor Trading Co. Ltd.
+    Copyright 2019 Red Anchor Trading Co. Ltd.
 
     Distributed under the Boost Software License, Version 1.0.
     See <http://www.boost.org/LICENSE_1_0.txt>

--- a/Cpp/fost-urlhandler-test/web-proxy.cpp
+++ b/Cpp/fost-urlhandler-test/web-proxy.cpp
@@ -1,0 +1,26 @@
+/**
+    Copyright 2012-2019 Red Anchor Trading Co. Ltd.
+
+    Distributed under the Boost Software License, Version 1.0.
+    See <http://www.boost.org/LICENSE_1_0.txt>
+ */
+
+
+#include <fost/urlhandler>
+#include <fost/test>
+
+
+FSL_TEST_SUITE(web_proxy);
+
+
+/// Connect to an upstream server over HTTP
+FSL_TEST_FUNCTION(http) {}
+
+
+/// Connect to an upstream server using TLS
+FSL_TEST_FUNCTION(https) {}
+
+
+/// Connect to an upstream server where the host header
+/// has to be replaced to function correctly.
+FSL_TEST_FUNCTION(host_replacement) {}

--- a/Cpp/fost-urlhandler/responses.proxy.cpp
+++ b/Cpp/fost-urlhandler/responses.proxy.cpp
@@ -7,7 +7,7 @@
 
 
 #include "fost-urlhandler.hpp"
-#include <fost/urlhandler.hpp>
+#include <fost/web-proxy.hpp>
 #include <fost/log>
 #include <fost/timer>
 
@@ -36,6 +36,7 @@ namespace {
             fostlib::url location(base, path);
             location.query(request.query_string());
             info("proxy", "url", location);
+            info("proxy", "headers", request.data()->headers());
 
             fostlib::http::user_agent ua(base);
             fostlib::http::user_agent::request proxy(

--- a/Cpp/fost-urlhandler/responses.proxy.cpp
+++ b/Cpp/fost-urlhandler/responses.proxy.cpp
@@ -15,46 +15,63 @@
 namespace {
 
 
-    class proxy_base : public fostlib::urlhandler::view {
-      protected:
-        proxy_base(f5::u8view const n) : view(n) {}
-
-
-        std::pair<boost::shared_ptr<fostlib::mime>, int> operator()(
-                const fostlib::json &configuration,
-                const fostlib::string &path,
-                fostlib::http::server::request &request,
-                const fostlib::host &host) const override {
-            fostlib::timer time;
-            auto info = fostlib::log::info(fostlib::c_fost_web_urlhandler);
-            info("id", fostlib::guid())(
-                    "request", "path", "full", request.file_spec())(
-                    "request", "path", "outstanding", path);
-
-            fostlib::url base(
-                    fostlib::coerce<fostlib::string>(configuration["base"]));
-            fostlib::url location(base, path);
-            location.query(request.query_string());
-            info("proxy", "url", location);
-            info("proxy", "headers", request.data()->headers());
-
-            fostlib::http::user_agent ua(base);
-            fostlib::http::user_agent::request proxy(
-                    request.method(), location, request.data());
-            auto response = ua(proxy);
-            auto body{response->body()};
-            info("repsonse", "status", response->status());
-            info("time", time.seconds());
-
-            return std::make_pair(body, response->status());
-        }
-    };
-
-
-    const class transparent final : public proxy_base {
+    /**
+        The transparent proxy doesn't change the request or the
+        server response. It's used in situations where the web server
+        is intended to intercept a request and route it on as if it had
+        handled the request itself. This is normally done with the co-operation
+        of the upstream host.
+     */
+    const class transparent final : public fostlib::web_proxy::base {
       public:
-        transparent() : proxy_base("fost.proxy.transparent") {}
+        transparent() : base("fost.proxy.transparent") {}
+
     } c_transparent;
 
 
+}
+
+
+/**
+ * ## `fostlib::web_proxy::base`
+ */
+
+
+std::pair<boost::shared_ptr<fostlib::mime>, int>
+        fostlib::web_proxy::base::operator()(
+                json const &configuration,
+                string const &path,
+                http::server::request &request,
+                host const &host) const {
+    timer time;
+    auto info = log::info(fostlib::c_fost_web_urlhandler);
+    info("id", fostlib::guid());
+    info("request", "path", "full", request.file_spec());
+    info("request", "path", "outstanding", path);
+
+    url const base{coerce<string>(configuration["base"])};
+    auto const location = upstream(configuration, base, path, request, host);
+    info("proxy", "url", location);
+    info("proxy", "headers", request.data()->headers());
+
+    http::user_agent ua(base);
+    http::user_agent::request proxy(request.method(), location, request.data());
+    auto response = ua(proxy);
+    auto body{response->body()};
+    info("repsonse", "status", response->status());
+    info("time", time.seconds());
+
+    return std::make_pair(body, response->status());
+}
+
+
+fostlib::url fostlib::web_proxy::base::upstream(
+        json const &configuration,
+        url const &base,
+        string const &path,
+        http::server::request &request,
+        host const &host) const {
+    url location{base, path};
+    location.query(request.query_string());
+    return location;
 }

--- a/Cpp/fost-urlhandler/responses.proxy.cpp
+++ b/Cpp/fost-urlhandler/responses.proxy.cpp
@@ -15,9 +15,9 @@
 namespace {
 
 
-    const class proxy_view final : public fostlib::urlhandler::view {
-      public:
-        proxy_view() : view("fost.proxy.transparent") {}
+    class proxy_base : public fostlib::urlhandler::view {
+      protected:
+        proxy_base(f5::u8view const n) : view(n) {}
 
 
         std::pair<boost::shared_ptr<fostlib::mime>, int> operator()(
@@ -48,8 +48,13 @@ namespace {
 
             return std::make_pair(body, response->status());
         }
+    };
 
-    } c_proxy_view;
+
+    const class transparent final : public proxy_base {
+      public:
+        transparent() : proxy_base("fost.proxy.transparent") {}
+    } c_transparent;
 
 
 }

--- a/Cpp/include/fost/urlhandler
+++ b/Cpp/include/fost/urlhandler
@@ -6,6 +6,9 @@
  */
 
 
+#pragma once
+
+
 #ifdef FOST_OS_WINDOWS
     #define FOST_URLHANDLER_DECLSPEC __declspec( dllimport )
 #else
@@ -14,15 +17,3 @@
 
 
 #include <fost/urlhandler.hpp>
-
-
-namespace fostlib {
-
-
-    namespace urlhandler {
-
-
-    }
-
-
-}

--- a/Cpp/include/fost/urlhandler.hpp
+++ b/Cpp/include/fost/urlhandler.hpp
@@ -6,13 +6,13 @@
  */
 
 
-#include <fost/internet>
-#include <fost/http.server.hpp>
-
-
 #pragma once
 #ifndef FOST_URLHANDLER_HPP
 #define FOST_URLHANDLER_HPP
+
+
+#include <fost/internet>
+#include <fost/http.server.hpp>
 
 
 namespace fostlib {

--- a/Cpp/include/fost/web-proxy
+++ b/Cpp/include/fost/web-proxy
@@ -1,0 +1,13 @@
+/**
+    Copyright 2019 Red Anchor Trading Co. Ltd.
+
+    Distributed under the Boost Software License, Version 1.0.
+    See <http://www.boost.org/LICENSE_1_0.txt>
+ */
+
+
+#pragma once
+
+
+#include <fost/urlhandler>
+#include <fost/web-proxy.hpp>

--- a/Cpp/include/fost/web-proxy.hpp
+++ b/Cpp/include/fost/web-proxy.hpp
@@ -1,0 +1,14 @@
+/**
+    Copyright 2019 Red Anchor Trading Co. Ltd.
+
+    Distributed under the Boost Software License, Version 1.0.
+    See <http://www.boost.org/LICENSE_1_0.txt>
+ */
+
+
+#pragma once
+
+#include <fost/urlhandler.hpp>
+
+
+namespace fostlib {}

--- a/Cpp/include/fost/web-proxy.hpp
+++ b/Cpp/include/fost/web-proxy.hpp
@@ -40,6 +40,16 @@ namespace fostlib::web_proxy {
                 http::server::request &request,
                 host const &host) const;
 
+        /// All the proxy to alter any aspect of the response it wishes
+        virtual std::pair<boost::shared_ptr<mime>, int>
+                respond(json const &configuration,
+                        url const &location,
+                        string const &path,
+                        http::server::request const &request,
+                        host const &host,
+                        boost::shared_ptr<mime> body,
+                        int status) const;
+
       private:
         std::pair<boost::shared_ptr<mime>, int> operator()(
                 json const &configuration,

--- a/Cpp/include/fost/web-proxy.hpp
+++ b/Cpp/include/fost/web-proxy.hpp
@@ -28,6 +28,15 @@ namespace fostlib::web_proxy {
                 json const &configuration,
                 url const &base,
                 string const &path,
+                http::server::request const &request,
+                host const &host) const;
+
+        /// Return the request that is to be used by the user agent making
+        /// talking to the upstream web server.
+        virtual http::user_agent::request ua_request(
+                json const &configuration,
+                url location,
+                string const &path,
                 http::server::request &request,
                 host const &host) const;
 

--- a/Cpp/include/fost/web-proxy.hpp
+++ b/Cpp/include/fost/web-proxy.hpp
@@ -8,7 +8,36 @@
 
 #pragma once
 
+
 #include <fost/urlhandler.hpp>
 
 
-namespace fostlib {}
+namespace fostlib::web_proxy {
+
+
+    /// ## `base`
+    /**
+        Abstract class that defines the basics of the different proxy types.
+    */
+    class base : public fostlib::urlhandler::view {
+      protected:
+        base(f5::u8view const n) : view(n) {}
+
+        /// Customisation point for determining the new URL that is to be used
+        virtual url upstream(
+                json const &configuration,
+                url const &base,
+                string const &path,
+                http::server::request &request,
+                host const &host) const;
+
+      private:
+        std::pair<boost::shared_ptr<mime>, int> operator()(
+                json const &configuration,
+                string const &path,
+                http::server::request &request,
+                host const &host) const override;
+    };
+
+
+}


### PR DESCRIPTION
This creates a new proxy type, reverse, which can be used when the proxy needs to replace an upstream server and act as it. Unlike a transparent proxy, reverse proxies alter Host and Location headers as needed.