### PR TITLE
Feature/replace middleware

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+2020-02-12  Kirit Saelensminde  <kirit@felspar.com>
+ Deprecate use of view instances.
+
 2019-11-06  Kirit Saelensminde  <kirit@felspar.com>
  Add a reverse proxy view that allows for changes in request and response.
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,6 @@
 2020-02-12  Kirit Saelensminde  <kirit@felspar.com>
- Deprecate use of view instances.
+ * Add middleware that can replace response text with fixed strings or setting values.
+ * Deprecate use of view instances.
 
 2019-11-06  Kirit Saelensminde  <kirit@felspar.com>
  Add a reverse proxy view that allows for changes in request and response.

--- a/Cpp/fost-urlhandler/CMakeLists.txt
+++ b/Cpp/fost-urlhandler/CMakeLists.txt
@@ -4,6 +4,7 @@ add_library(fost-urlhandler
         control.status-condition.cpp
         fost-urlhandler.cpp
         middleware.logging.cpp
+        middleware.replace.cpp
         middleware.request.cpp
         middleware.template.cpp
         mime-types.cpp
@@ -33,6 +34,7 @@ if(TARGET check)
     add_library(fost-urlhandler-smoke STATIC EXCLUDE_FROM_ALL
             control.exception.tests.cpp
             control.status-condition-tests.cpp
+            middleware.replace.tests.cpp
             responses.tests.cpp
             responses.301-tests.cpp
             responses.302-tests.cpp

--- a/Cpp/fost-urlhandler/control.exception.tests.cpp
+++ b/Cpp/fost-urlhandler/control.exception.tests.cpp
@@ -1,5 +1,5 @@
 /**
-    Copyright 2019 Red Anchor Trading Co. Ltd.
+    Copyright 2019-2020 Red Anchor Trading Co. Ltd.
 
     Distributed under the Boost Software License, Version 1.0.
     See <http://www.boost.org/LICENSE_1_0.txt>
@@ -15,39 +15,43 @@ FSL_TEST_SUITE(catch_exception);
 
 FSL_TEST_FUNCTION(try_works) {
     fostlib::json config;
-    fostlib::insert(config, "try", "fost.response.200");
+    fostlib::insert(config, "view", "control.exception.catch");
+    fostlib::insert(config, "configuration", "try", "fost.response.200");
     fostlib::http::server::request req;
-    auto const [response, status] =
-            fostlib::urlhandler::control_exception_catch(
-                    config, "", req, fostlib::host{});
+    auto const [response, status] = fostlib::urlhandler::view::execute(
+            config, "", req, fostlib::host{});
     FSL_CHECK_EQ(status, 200);
 }
 
 
 FSL_TEST_FUNCTION(catches_std_exception) {
     fostlib::json config;
-    fostlib::insert(config, "try", "view", "test.throw");
+    fostlib::insert(config, "view", "control.exception.catch");
+    fostlib::insert(config, "configuration", "try", "view", "test.throw");
     fostlib::insert(
-            config, "try", "configuration", "exception", "std::logic_error");
-    fostlib::insert(config, "catch", "std::exception", "fost.response.200");
+            config, "configuration", "try", "configuration", "exception",
+            "std::logic_error");
+    fostlib::insert(
+            config, "configuration", "catch", "std::exception",
+            "fost.response.200");
     fostlib::http::server::request req;
-    auto const [response, status] =
-            fostlib::urlhandler::control_exception_catch(
-                    config, "", req, fostlib::host{});
+    auto const [response, status] = fostlib::urlhandler::view::execute(
+            config, "", req, fostlib::host{});
     FSL_CHECK_EQ(status, 200);
 }
 
 
 FSL_TEST_FUNCTION(missing_catch_rethrows) {
     fostlib::json config;
-    fostlib::insert(config, "try", "view", "test.throw");
+    fostlib::insert(config, "view", "control.exception.catch");
+    fostlib::insert(config, "configuration", "try", "view", "test.throw");
     fostlib::insert(
-            config, "try", "configuration", "exception", "std::logic_error");
+            config, "configuration", "try", "configuration", "exception",
+            "std::logic_error");
     fostlib::http::server::request req;
     try {
-        auto const [response, status] =
-                fostlib::urlhandler::control_exception_catch(
-                        config, "", req, fostlib::host{});
+        auto const [response, status] = fostlib::urlhandler::view::execute(
+                config, "", req, fostlib::host{});
         FSL_CHECK(false);
     } catch (const std::logic_error &) {
         // OK, test passed

--- a/Cpp/fost-urlhandler/control.status-condition-tests.cpp
+++ b/Cpp/fost-urlhandler/control.status-condition-tests.cpp
@@ -1,5 +1,5 @@
 /**
-    Copyright 2018-2019 Red Anchor Trading Co. Ltd.
+    Copyright 2018-2020 Red Anchor Trading Co. Ltd.
 
     Distributed under the Boost Software License, Version 1.0.
     See <http://www.boost.org/LICENSE_1_0.txt>
@@ -15,21 +15,23 @@ FSL_TEST_SUITE(control_status_condition);
 
 FSL_TEST_FUNCTION(execute_then_if_less_than_400) {
     fostlib::json config;
-    fostlib::insert(config, "if", "fost.response.200");
-    fostlib::insert(config, "then", "fost.response.404");
+    fostlib::insert(config, "view", "fost.control.status-condition");
+    fostlib::insert(config, "configuration", "if", "fost.response.200");
+    fostlib::insert(config, "configuration", "then", "fost.response.404");
     fostlib::http::server::request req;
     std::pair<boost::shared_ptr<fostlib::mime>, int> response{
-            fostlib::urlhandler::control_status_condition(
+            fostlib::urlhandler::view::execute(
                     config, "/", req, fostlib::host())};
     FSL_CHECK_EQ(response.second, 404);
 }
 
 FSL_TEST_FUNCTION(return_if_default) {
     fostlib::json config;
-    fostlib::insert(config, "if", "fost.response.200");
+    fostlib::insert(config, "view", "fost.control.status-condition");
+    fostlib::insert(config, "configuration", "if", "fost.response.200");
     fostlib::http::server::request req;
     std::pair<boost::shared_ptr<fostlib::mime>, int> response{
-            fostlib::urlhandler::control_status_condition(
+            fostlib::urlhandler::view::execute(
                     config, "/", req, fostlib::host())};
     FSL_CHECK_EQ(response.second, 200);
 }
@@ -37,32 +39,35 @@ FSL_TEST_FUNCTION(return_if_default) {
 
 FSL_TEST_FUNCTION(return_specific_then) {
     fostlib::json config;
-    fostlib::insert(config, "if", "fost.response.200");
-    fostlib::insert(config, "then.200", "fost.response.404");
+    fostlib::insert(config, "view", "fost.control.status-condition");
+    fostlib::insert(config, "configuration", "if", "fost.response.200");
+    fostlib::insert(config, "configuration", "then.200", "fost.response.404");
     fostlib::http::server::request req;
     std::pair<boost::shared_ptr<fostlib::mime>, int> response{
-            fostlib::urlhandler::control_status_condition(
+            fostlib::urlhandler::view::execute(
                     config, "/", req, fostlib::host())};
     FSL_CHECK_EQ(response.second, 404);
 }
 
 FSL_TEST_FUNCTION(execute_else_if_more_than_400) {
     fostlib::json config;
-    fostlib::insert(config, "if", "fost.response.404");
-    fostlib::insert(config, "else", "fost.response.200");
+    fostlib::insert(config, "view", "fost.control.status-condition");
+    fostlib::insert(config, "configuration", "if", "fost.response.404");
+    fostlib::insert(config, "configuration", "else", "fost.response.200");
     fostlib::http::server::request req;
     std::pair<boost::shared_ptr<fostlib::mime>, int> response{
-            fostlib::urlhandler::control_status_condition(
+            fostlib::urlhandler::view::execute(
                     config, "/", req, fostlib::host())};
     FSL_CHECK_EQ(response.second, 200);
 }
 
 FSL_TEST_FUNCTION(return_response_if_more_than_400_without_else) {
     fostlib::json config;
-    fostlib::insert(config, "if", "fost.response.404");
+    fostlib::insert(config, "view", "fost.control.status-condition");
+    fostlib::insert(config, "configuration", "if", "fost.response.404");
     fostlib::http::server::request req;
     std::pair<boost::shared_ptr<fostlib::mime>, int> response{
-            fostlib::urlhandler::control_status_condition(
+            fostlib::urlhandler::view::execute(
                     config, "/", req, fostlib::host())};
     FSL_CHECK_EQ(response.second, 404);
 }

--- a/Cpp/fost-urlhandler/middleware.replace.cpp
+++ b/Cpp/fost-urlhandler/middleware.replace.cpp
@@ -1,0 +1,43 @@
+/**
+    Copyright 2020 Red Anchor Trading Co. Ltd.
+
+    Distributed under the Boost Software License, Version 1.0.
+    See <http://www.boost.org/LICENSE_1_0.txt>
+ */
+
+
+#include "fost-urlhandler.hpp"
+#include <fost/urlhandler.hpp>
+
+
+namespace {
+
+
+    const class middleware_template final : public fostlib::urlhandler::view {
+      public:
+        middleware_template() : view("fost.middleware.replace") {}
+
+        std::pair<boost::shared_ptr<fostlib::mime>, int> operator()(
+                const fostlib::json &configuration,
+                const fostlib::string &path,
+                fostlib::http::server::request &req,
+                const fostlib::host &h) const {
+            auto const wrapped = execute(configuration, path, req, h);
+            if (configuration.has_key("replace") /* TODO check media type */) {
+                fostlib::string text = wrapped.first->body_as_string();
+                for (auto const &[str, with] :
+                     configuration["replace"].object()) {
+                    text = fostlib::replace_all(
+                            text, str, fostlib::coerce<f5::u8view>(with));
+                }
+                return {boost::make_shared<fostlib::text_body>(
+                                text, wrapped.first->headers()),
+                        wrapped.second};
+            } else {
+                return wrapped;
+            }
+        }
+    } c_middleware_replace;
+
+
+}

--- a/Cpp/fost-urlhandler/middleware.replace.tests.cpp
+++ b/Cpp/fost-urlhandler/middleware.replace.tests.cpp
@@ -1,0 +1,40 @@
+/**
+    Copyright 2020 Red Anchor Trading Co. Ltd.
+
+    Distributed under the Boost Software License, Version 1.0.
+    See <http://www.boost.org/LICENSE_1_0.txt>
+ */
+
+
+#include <fost/urlhandler>
+#include <fost/test>
+
+
+FSL_TEST_SUITE(middleware_replace);
+
+
+FSL_TEST_FUNCTION(nop) {
+    fostlib::json config;
+    fostlib::insert(config, "view", "fost.middleware.replace");
+    fostlib::insert(config, "configuration", "view", "fost.response.200");
+    fostlib::http::server::request req;
+    auto response = fostlib::urlhandler::view::execute(
+            config, "", req, fostlib::host{});
+    FSL_CHECK_EQ(response.second, 200);
+}
+
+
+FSL_TEST_FUNCTION(simple) {
+    fostlib::json config;
+    fostlib::insert(config, "view", "fost.middleware.replace");
+    fostlib::insert(config, "configuration", "view", "fost.response.200");
+    fostlib::insert(config, "configuration", "replace", "OK", "Very OK");
+    fostlib::http::server::request req;
+    auto response = fostlib::urlhandler::view::execute(
+            config, "", req, fostlib::host{});
+    FSL_CHECK_EQ(response.second, 200);
+    FSL_CHECK_EQ(
+            response.first->body_as_string(),
+            "<html><head><title>Very OK</title></head><body><h1>Very "
+            "OK</h1></body></html>");
+}

--- a/Cpp/fost-urlhandler/middleware.replace.tests.cpp
+++ b/Cpp/fost-urlhandler/middleware.replace.tests.cpp
@@ -7,6 +7,7 @@
 
 
 #include <fost/urlhandler>
+#include <fost/push_back>
 #include <fost/test>
 
 
@@ -37,4 +38,68 @@ FSL_TEST_FUNCTION(simple) {
             response.first->body_as_string(),
             "<html><head><title>Very OK</title></head><body><h1>Very "
             "OK</h1></body></html>");
+}
+
+
+FSL_TEST_FUNCTION(setting) {
+    fostlib::setting<fostlib::string> const s{"middleware.replace.tests.cpp",
+                                              "Test middleware", "Replacement",
+                                              "Very OK", true};
+    fostlib::json config;
+    fostlib::insert(config, "view", "fost.middleware.replace");
+    fostlib::insert(config, "configuration", "view", "fost.response.200");
+    fostlib::push_back(config, "configuration", "replace", "OK", "setting");
+    fostlib::push_back(config, "configuration", "replace", "OK", s.section());
+    fostlib::push_back(config, "configuration", "replace", "OK", s.name());
+    fostlib::http::server::request req;
+    auto response = fostlib::urlhandler::view::execute(
+            config, "", req, fostlib::host{});
+    FSL_CHECK_EQ(response.second, 200);
+    FSL_CHECK_EQ(
+            response.first->body_as_string(),
+            "<html><head><title>Very OK</title></head><body><h1>Very "
+            "OK</h1></body></html>");
+}
+
+
+FSL_TEST_FUNCTION(setting_with_default) {
+    fostlib::json config;
+    fostlib::insert(config, "view", "fost.middleware.replace");
+    fostlib::insert(config, "configuration", "view", "fost.response.200");
+    fostlib::push_back(config, "configuration", "replace", "OK", "setting");
+    fostlib::push_back(
+            config, "configuration", "replace", "OK", "Test middleware");
+    fostlib::push_back(
+            config, "configuration", "replace", "OK", "Not a setting value");
+    fostlib::push_back(config, "configuration", "replace", "OK", "Default");
+    fostlib::http::server::request req;
+    auto response = fostlib::urlhandler::view::execute(
+            config, "", req, fostlib::host{});
+    FSL_CHECK_EQ(response.second, 200);
+    FSL_CHECK_EQ(
+            response.first->body_as_string(),
+            "<html><head><title>Default</title></head><body><h1>Default</h1></"
+            "body></html>");
+}
+
+
+FSL_TEST_FUNCTION(setting_with_default_object) {
+    fostlib::json config;
+    fostlib::insert(config, "view", "fost.middleware.replace");
+    fostlib::insert(config, "configuration", "view", "fost.response.200");
+    fostlib::push_back(config, "configuration", "replace", "OK", "setting");
+    fostlib::push_back(
+            config, "configuration", "replace", "OK", "Test middleware");
+    fostlib::push_back(
+            config, "configuration", "replace", "OK", "Not a setting value");
+    fostlib::jcursor{"configuration", "replace", "OK"}.push_back(
+            config, fostlib::json::object_t{});
+    fostlib::http::server::request req;
+    auto response = fostlib::urlhandler::view::execute(
+            config, "", req, fostlib::host{});
+    FSL_CHECK_EQ(response.second, 200);
+    FSL_CHECK_EQ(
+            response.first->body_as_string(),
+            "<html><head><title>{}</title></head><body><h1>{}</h1></body></"
+            "html>");
 }

--- a/Cpp/fost-urlhandler/responses.301-tests.cpp
+++ b/Cpp/fost-urlhandler/responses.301-tests.cpp
@@ -1,5 +1,5 @@
 /**
-    Copyright 2012-2019 Red Anchor Trading Co. Ltd.
+    Copyright 2012-2020 Red Anchor Trading Co. Ltd.
 
     Distributed under the Boost Software License, Version 1.0.
     See <http://www.boost.org/LICENSE_1_0.txt>
@@ -16,18 +16,20 @@ FSL_TEST_SUITE(response_301);
 FSL_TEST_FUNCTION(no_location_config) {
     fostlib::http::server::request req;
     FSL_CHECK_EXCEPTION(
-            fostlib::urlhandler::response_301(
-                    fostlib::json(), "/", req, fostlib::host()),
+            fostlib::urlhandler::view::execute(
+                    fostlib::json{"fost.response.301"}, "/", req,
+                    fostlib::host()),
             fostlib::exceptions::not_implemented &);
 }
 
 
 FSL_TEST_FUNCTION(empty_location_config) {
     fostlib::json location;
-    fostlib::insert(location, "location", "");
+    fostlib::insert(location, "view", "fost.response.301");
+    fostlib::insert(location, "configuration", "location", "");
     fostlib::http::server::request req;
     FSL_CHECK_EXCEPTION(
-            fostlib::urlhandler::response_301(
+            fostlib::urlhandler::view::execute(
                     location, "/", req, fostlib::host()),
             fostlib::exceptions::not_implemented &);
 }
@@ -35,10 +37,12 @@ FSL_TEST_FUNCTION(empty_location_config) {
 
 FSL_TEST_FUNCTION(with_location_config) {
     fostlib::json location;
-    fostlib::insert(location, "location", "http://test.example.com/");
+    fostlib::insert(location, "view", "fost.response.301");
+    fostlib::insert(
+            location, "configuration", "location", "http://test.example.com/");
     fostlib::http::server::request req;
     std::pair<boost::shared_ptr<fostlib::mime>, int> response(
-            fostlib::urlhandler::response_301(
+            fostlib::urlhandler::view::execute(
                     location, "/", req, fostlib::host()));
     FSL_CHECK_EQ(response.second, 301);
     FSL_CHECK_EQ(

--- a/Cpp/fost-urlhandler/responses.302-tests.cpp
+++ b/Cpp/fost-urlhandler/responses.302-tests.cpp
@@ -1,5 +1,5 @@
 /**
-    Copyright 2012-2019 Red Anchor Trading Co. Ltd.
+    Copyright 2012-2020 Red Anchor Trading Co. Ltd.
 
     Distributed under the Boost Software License, Version 1.0.
     See <http://www.boost.org/LICENSE_1_0.txt>
@@ -16,18 +16,20 @@ FSL_TEST_SUITE(response_302);
 FSL_TEST_FUNCTION(no_location_config) {
     fostlib::http::server::request req;
     FSL_CHECK_EXCEPTION(
-            fostlib::urlhandler::response_302(
-                    fostlib::json(), "/", req, fostlib::host()),
+            fostlib::urlhandler::view::execute(
+                    fostlib::json{"fost.response.302"}, "/", req,
+                    fostlib::host()),
             fostlib::exceptions::not_implemented &);
 }
 
 
 FSL_TEST_FUNCTION(empty_location_config) {
     fostlib::json location;
-    fostlib::insert(location, "location", "");
+    fostlib::insert(location, "view", "fost.response.302");
+    fostlib::insert(location, "configuration", "location", "");
     fostlib::http::server::request req;
     FSL_CHECK_EXCEPTION(
-            fostlib::urlhandler::response_302(
+            fostlib::urlhandler::view::execute(
                     location, "/", req, fostlib::host()),
             fostlib::exceptions::not_implemented &);
 }
@@ -35,10 +37,12 @@ FSL_TEST_FUNCTION(empty_location_config) {
 
 FSL_TEST_FUNCTION(with_location_config) {
     fostlib::json location;
-    fostlib::insert(location, "location", "http://test.example.com/");
+    fostlib::insert(location, "view", "fost.response.302");
+    fostlib::insert(
+            location, "configuration", "location", "http://test.example.com/");
     fostlib::http::server::request req;
     std::pair<boost::shared_ptr<fostlib::mime>, int> response(
-            fostlib::urlhandler::response_302(
+            fostlib::urlhandler::view::execute(
                     location, "/", req, fostlib::host()));
     FSL_CHECK_EQ(response.second, 302);
     FSL_CHECK_EQ(

--- a/Cpp/fost-urlhandler/responses.303-tests.cpp
+++ b/Cpp/fost-urlhandler/responses.303-tests.cpp
@@ -1,5 +1,5 @@
 /**
-    Copyright 2012-2019 Red Anchor Trading Co. Ltd.
+    Copyright 2012-2020 Red Anchor Trading Co. Ltd.
 
     Distributed under the Boost Software License, Version 1.0.
     See <http://www.boost.org/LICENSE_1_0.txt>
@@ -16,18 +16,20 @@ FSL_TEST_SUITE(response_303);
 FSL_TEST_FUNCTION(no_location_config) {
     fostlib::http::server::request req;
     FSL_CHECK_EXCEPTION(
-            fostlib::urlhandler::response_303(
-                    fostlib::json(), "/", req, fostlib::host()),
+            fostlib::urlhandler::view::execute(
+                    fostlib::json{"fost.response.303"}, "/", req,
+                    fostlib::host()),
             fostlib::exceptions::not_implemented &);
 }
 
 
 FSL_TEST_FUNCTION(empty_location_config) {
     fostlib::json location;
-    fostlib::insert(location, "location", "");
+    fostlib::insert(location, "view", "fost.response.303");
+    fostlib::insert(location, "configuration", "location", "");
     fostlib::http::server::request req;
     FSL_CHECK_EXCEPTION(
-            fostlib::urlhandler::response_303(
+            fostlib::urlhandler::view::execute(
                     location, "/", req, fostlib::host()),
             fostlib::exceptions::not_implemented &);
 }
@@ -35,10 +37,12 @@ FSL_TEST_FUNCTION(empty_location_config) {
 
 FSL_TEST_FUNCTION(with_location_config) {
     fostlib::json location;
-    fostlib::insert(location, "location", "http://test.example.com/");
+    fostlib::insert(location, "view", "fost.response.303");
+    fostlib::insert(
+            location, "configuration", "location", "http://test.example.com/");
     fostlib::http::server::request req;
     std::pair<boost::shared_ptr<fostlib::mime>, int> response(
-            fostlib::urlhandler::response_303(
+            fostlib::urlhandler::view::execute(
                     location, "/", req, fostlib::host()));
     FSL_CHECK_EQ(response.second, 303);
     FSL_CHECK_EQ(

--- a/Cpp/fost-urlhandler/responses.405-tests.cpp
+++ b/Cpp/fost-urlhandler/responses.405-tests.cpp
@@ -1,5 +1,5 @@
 /**
-    Copyright 2012-2019 Red Anchor Trading Co. Ltd.
+    Copyright 2012-2020 Red Anchor Trading Co. Ltd.
 
     Distributed under the Boost Software License, Version 1.0.
     See <http://www.boost.org/LICENSE_1_0.txt>
@@ -17,18 +17,20 @@ FSL_TEST_SUITE(response_405);
 FSL_TEST_FUNCTION(no_allows_config) {
     fostlib::http::server::request req;
     FSL_CHECK_EXCEPTION(
-            fostlib::urlhandler::response_405(
-                    fostlib::json(), "/", req, fostlib::host()),
+            fostlib::urlhandler::view::execute(
+                    fostlib::json{"fost.response.405"}, "/", req,
+                    fostlib::host()),
             fostlib::exceptions::not_implemented &);
 }
 
 
 FSL_TEST_FUNCTION(empty_allows_config) {
     fostlib::json allows;
-    fostlib::insert(allows, "allow", fostlib::json::array_t());
+    fostlib::insert(allows, "view", "fost.response.405");
+    fostlib::insert(allows, "configuration", "allow", fostlib::json::array_t());
     fostlib::http::server::request req;
     std::pair<boost::shared_ptr<fostlib::mime>, int> response(
-            fostlib::urlhandler::response_405(
+            fostlib::urlhandler::view::execute(
                     allows, "/", req, fostlib::host()));
     FSL_CHECK_EQ(response.second, 405);
     FSL_CHECK(response.first->headers().exists("Allow"));
@@ -38,10 +40,11 @@ FSL_TEST_FUNCTION(empty_allows_config) {
 
 FSL_TEST_FUNCTION(one_allows_config) {
     fostlib::json allows;
-    fostlib::push_back(allows, "allow", "GET");
+    fostlib::insert(allows, "view", "fost.response.405");
+    fostlib::push_back(allows, "configuration", "allow", "GET");
     fostlib::http::server::request req;
     std::pair<boost::shared_ptr<fostlib::mime>, int> response(
-            fostlib::urlhandler::response_405(
+            fostlib::urlhandler::view::execute(
                     allows, "/", req, fostlib::host()));
     FSL_CHECK_EQ(response.second, 405);
     FSL_CHECK_EQ(response.first->headers()["Allow"].value(), "GET");
@@ -50,11 +53,12 @@ FSL_TEST_FUNCTION(one_allows_config) {
 
 FSL_TEST_FUNCTION(multiple_allows_config) {
     fostlib::json allows;
-    fostlib::push_back(allows, "allow", "GET");
-    fostlib::push_back(allows, "allow", "POST");
+    fostlib::insert(allows, "view", "fost.response.405");
+    fostlib::push_back(allows, "configuration", "allow", "GET");
+    fostlib::push_back(allows, "configuration", "allow", "POST");
     fostlib::http::server::request req;
     std::pair<boost::shared_ptr<fostlib::mime>, int> response(
-            fostlib::urlhandler::response_405(
+            fostlib::urlhandler::view::execute(
                     allows, "/", req, fostlib::host()));
     FSL_CHECK_EQ(response.second, 405);
     FSL_CHECK_EQ(response.first->headers()["Allow"].value(), "GET, POST");

--- a/Cpp/fost-urlhandler/responses.pathname.cpp
+++ b/Cpp/fost-urlhandler/responses.pathname.cpp
@@ -1,5 +1,5 @@
 /**
-    Copyright 2018-2019 Red Anchor Trading Co. Ltd.
+    Copyright 2018-2020 Red Anchor Trading Co. Ltd.
 
     Distributed under the Boost Software License, Version 1.0.
     See <http://www.boost.org/LICENSE_1_0.txt>
@@ -30,8 +30,8 @@ namespace {
                 /// matches in its entirety
                 return execute(configuration[path], "", req, h);
             } else {
-                return fostlib::urlhandler::response_404(
-                        fostlib::json(), path, req, h);
+                return execute(
+                        fostlib::json("fost.response.404"), path, req, h);
             }
         }
     } c_pathname;

--- a/Cpp/fost-urlhandler/responses.pathprefix.cpp
+++ b/Cpp/fost-urlhandler/responses.pathprefix.cpp
@@ -1,5 +1,5 @@
 /**
-    Copyright 2011-2019 Red Anchor Trading Co. Ltd.
+    Copyright 2011-2020 Red Anchor Trading Co. Ltd.
 
     Distributed under the Boost Software License, Version 1.0.
     See <http://www.boost.org/LICENSE_1_0.txt>
@@ -44,13 +44,14 @@ namespace {
                 }
             }
 
-            if (configuration.has_key(longest.second))
+            if (configuration.has_key(longest.second)) {
                 return execute(
                         configuration[longest.second],
                         path.substr(longest.first), req, h);
-            else
-                return fostlib::urlhandler::response_404(
-                        fostlib::json(), path, req, h);
+            } else {
+                return execute(
+                        fostlib::json{"fost.response.404"}, path, req, h);
+            }
         }
     } c_pathprefix;
 

--- a/Cpp/fost-urlhandler/schema.validate-tests.cpp
+++ b/Cpp/fost-urlhandler/schema.validate-tests.cpp
@@ -1,5 +1,5 @@
 /**
-    Copyright 2018-2019 Red Anchor Trading Co. Ltd.
+    Copyright 2018-2020 Red Anchor Trading Co. Ltd.
 
     Distributed under the Boost Software License, Version 1.0.
     See <http://www.boost.org/LICENSE_1_0.txt>
@@ -17,38 +17,43 @@ FSL_TEST_SUITE(schema_validation);
 FSL_TEST_FUNCTION(no_schema_config) {
     fostlib::http::server::request req;
     FSL_CHECK_EXCEPTION(
-            fostlib::urlhandler::schema_validation(
-                    fostlib::json(), "/", req, fostlib::host()),
+            fostlib::urlhandler::view::execute(
+                    fostlib::json{"fost.schema.validate"}, "/", req,
+                    fostlib::host()),
             fostlib::exceptions::not_implemented &);
 }
 
 FSL_TEST_FUNCTION(invalid_json_body) {
     fostlib::json config;
-    fostlib::insert(config, "schema", "type", "object");
+    fostlib::insert(config, "view", "fost.schema.validate");
+    fostlib::insert(config, "configuration", "schema", "type", "object");
     fostlib::insert(
-            config, "schema", "properties", "is_valid", "type", "boolean");
+            config, "configuration", "schema", "properties", "is_valid", "type",
+            "boolean");
     fostlib::mime::mime_headers headers;
     auto body = std::make_unique<fostlib::binary_body>(
             fostlib::coerce<std::vector<unsigned char>>(
                     fostlib::utf8_string("{\"is_valid\": \"Hello\"}")));
     fostlib::http::server::request req{"GET", "/", std::move(body)};
-    auto response(fostlib::urlhandler::schema_validation(
+    auto response(fostlib::urlhandler::view::execute(
             config, "/", req, fostlib::host()));
     FSL_CHECK_EQ(response.second, 422);
 }
 
 FSL_TEST_FUNCTION(valid_json_body) {
     fostlib::json config;
-    fostlib::insert(config, "schema", "type", "object");
+    fostlib::insert(config, "view", "fost.schema.validate");
+    fostlib::insert(config, "configuration", "schema", "type", "object");
     fostlib::insert(
-            config, "schema", "properties", "is_valid", "type", "boolean");
-    fostlib::insert(config, "valid", "fost.response.200");
+            config, "configuration", "schema", "properties", "is_valid", "type",
+            "boolean");
+    fostlib::insert(config, "configuration", "valid", "fost.response.200");
     fostlib::mime::mime_headers headers;
     auto body = std::make_unique<fostlib::binary_body>(
             fostlib::coerce<std::vector<unsigned char>>(
                     fostlib::utf8_string("{\"is_valid\": true}")));
     fostlib::http::server::request req{"GET", "/", std::move(body)};
-    auto response(fostlib::urlhandler::schema_validation(
+    auto response(fostlib::urlhandler::view::execute(
             config, "/", req, fostlib::host()));
     FSL_CHECK_EQ(response.second, 200);
 }

--- a/Cpp/fost-urlhandler/test.throw.tests.cpp
+++ b/Cpp/fost-urlhandler/test.throw.tests.cpp
@@ -1,5 +1,5 @@
 /**
-    Copyright 2019 Red Anchor Trading Co. Ltd.
+    Copyright 2019-2020 Red Anchor Trading Co. Ltd.
 
     Distributed under the Boost Software License, Version 1.0.
     See <http://www.boost.org/LICENSE_1_0.txt>
@@ -17,9 +17,10 @@ FSL_TEST_SUITE(throw_exception);
 
 FSL_TEST_FUNCTION(empty_config) {
     fostlib::json config;
+    fostlib::insert(config, "view", "test.throw");
     fostlib::http::server::request req;
     try {
-        auto const response{fostlib::urlhandler::test_throw(
+        auto const response{fostlib::urlhandler::view::execute(
                 config, "", req, fostlib::host{})};
         FSL_CHECK(false);
     } catch (const std::invalid_argument &) {}
@@ -28,10 +29,11 @@ FSL_TEST_FUNCTION(empty_config) {
 
 FSL_TEST_FUNCTION(logic_error) {
     fostlib::json config;
-    fostlib::insert(config, "exception", "std::logic_error");
+    fostlib::insert(config, "view", "test.throw");
+    fostlib::insert(config, "configuration", "exception", "std::logic_error");
     fostlib::http::server::request req;
     try {
-        auto const response{fostlib::urlhandler::test_throw(
+        auto const response{fostlib::urlhandler::view::execute(
                 config, "", req, fostlib::host{})};
         FSL_CHECK(false);
     } catch (const std::logic_error &e) {
@@ -39,9 +41,9 @@ FSL_TEST_FUNCTION(logic_error) {
                 e.what(),
                 std::string{"Test exception message from test.throw"});
     }
-    fostlib::insert(config, "message", "Message set");
+    insert(config, "configuration", "message", "Message set");
     try {
-        auto const response{fostlib::urlhandler::test_throw(
+        auto const response{fostlib::urlhandler::view::execute(
                 config, "", req, fostlib::host{})};
         FSL_CHECK(false);
     } catch (const std::logic_error &e) {

--- a/Cpp/include/fost/urlhandler.hpp
+++ b/Cpp/include/fost/urlhandler.hpp
@@ -1,5 +1,5 @@
 /**
-    Copyright 2011-2019 Red Anchor Trading Co. Ltd.
+    Copyright 2011-2020 Red Anchor Trading Co. Ltd.
 
     Distributed under the Boost Software License, Version 1.0.
     See <http://www.boost.org/LICENSE_1_0.txt>
@@ -88,94 +88,96 @@ namespace fostlib {
         /// ## Test views
 
         /// Throw an exception
-        FOST_URLHANDLER_DECLSPEC
-        extern const view &test_throw;
+        FOST_URLHANDLER_DECLSPEC [[deprecated(
+                "Use view::execute")]] extern const view &test_throw;
 
         /// ## Control flow views
 
         /// Routing to new views based on status condition
         FOST_URLHANDLER_DECLSPEC
-        extern const view &control_status_condition;
+                [[deprecated("Use view::execute")]] extern const view
+                        &control_status_condition;
         /// Catching exceptions and routing to different views
         FOST_URLHANDLER_DECLSPEC
-        extern const view &control_exception_catch;
+                [[deprecated("Use view::execute")]] extern const view
+                        &control_exception_catch;
 
 
         /// Runs the view found at the location with the longest prefix
-        FOST_URLHANDLER_DECLSPEC
-        extern const view &view_pathprefix;
+        FOST_URLHANDLER_DECLSPEC [[deprecated(
+                "Use view::execute")]] extern const view &view_pathprefix;
         /// Serves the view found based on an exact match of the URL
-        FOST_URLHANDLER_DECLSPEC
-        extern const view &view_pathname;
+        FOST_URLHANDLER_DECLSPEC [[deprecated(
+                "Use view::execute")]] extern const view &view_pathname;
 
 
         /// ## Middleware
 
         /// Log the request and results
-        FOST_URLHANDLER_DECLSPEC
-        extern const view &middleware_logging;
+        FOST_URLHANDLER_DECLSPEC [[deprecated(
+                "Use view::execute")]] extern const view &middleware_logging;
         /// Alter the requests parameters before processing
-        FOST_URLHANDLER_DECLSPEC
-        extern const view &middleware_request;
+        FOST_URLHANDLER_DECLSPEC [[deprecated(
+                "Use view::execute")]] extern const view &middleware_request;
         /// Wrap a template around a response
-        FOST_URLHANDLER_DECLSPEC
-        extern const view &middleware_template;
+        FOST_URLHANDLER_DECLSPEC [[deprecated(
+                "Use view::execute")]] extern const view &middleware_template;
 
         /// request body JSON Schema validation
-        FOST_URLHANDLER_DECLSPEC
-        extern const view &schema_validation;
+        FOST_URLHANDLER_DECLSPEC [[deprecated(
+                "Use view::execute")]] extern const view &schema_validation;
 
         /// Generic response handler
-        FOST_URLHANDLER_DECLSPEC
-        extern const view &response_generic;
+        FOST_URLHANDLER_DECLSPEC [[deprecated(
+                "Use view::execute")]] extern const view &response_generic;
 
         /// ## Standard responses
 
         /// Return a 200 response to the user
-        FOST_URLHANDLER_DECLSPEC
-        extern const view &response_200;
+        FOST_URLHANDLER_DECLSPEC [[deprecated(
+                "Use view::execute")]] extern const view &response_200;
         /// Used to return a standard 301 to the user
-        FOST_URLHANDLER_DECLSPEC
-        extern const view &response_301;
+        FOST_URLHANDLER_DECLSPEC [[deprecated(
+                "Use view::execute")]] extern const view &response_301;
         /// Used to return a standard 302 to the user
-        FOST_URLHANDLER_DECLSPEC
-        extern const view &response_302;
+        FOST_URLHANDLER_DECLSPEC [[deprecated(
+                "Use view::execute")]] extern const view &response_302;
         /// Used to return a standard 303 to the user
-        FOST_URLHANDLER_DECLSPEC
-        extern const view &response_303;
+        FOST_URLHANDLER_DECLSPEC [[deprecated(
+                "Use view::execute")]] extern const view &response_303;
         /// Used to return a standard 403 to the user
-        FOST_URLHANDLER_DECLSPEC
-        extern const view &response_401;
-        FOST_URLHANDLER_DECLSPEC
-        extern const view &response_403;
+        FOST_URLHANDLER_DECLSPEC [[deprecated(
+                "Use view::execute")]] extern const view &response_401;
+        FOST_URLHANDLER_DECLSPEC [[deprecated(
+                "Use view::execute")]] extern const view &response_403;
         /// Used to return a standard 404 to the user
-        FOST_URLHANDLER_DECLSPEC
-        extern const view &response_404;
+        FOST_URLHANDLER_DECLSPEC [[deprecated(
+                "Use view::execute")]] extern const view &response_404;
         /// Used to return a standard 405 to the user
-        FOST_URLHANDLER_DECLSPEC
-        extern const view &response_405;
+        FOST_URLHANDLER_DECLSPEC [[deprecated(
+                "Use view::execute")]] extern const view &response_405;
         /// Used to return a standard 410 to the user
-        FOST_URLHANDLER_DECLSPEC
-        extern const view &response_410;
+        FOST_URLHANDLER_DECLSPEC [[deprecated(
+                "Use view::execute")]] extern const view &response_410;
         /// Used to return a standard 412 to the user
-        FOST_URLHANDLER_DECLSPEC
-        extern const view &response_412;
+        FOST_URLHANDLER_DECLSPEC [[deprecated(
+                "Use view::execute")]] extern const view &response_412;
         /// Used to return a standard 500 (internal server error) to the user
-        FOST_URLHANDLER_DECLSPEC
-        extern const view &response_500;
+        FOST_URLHANDLER_DECLSPEC [[deprecated(
+                "Use view::execute")]] extern const view &response_500;
         /// Used to return a standard 501 (not implemented) to the user
-        FOST_URLHANDLER_DECLSPEC
-        extern const view &response_501;
+        FOST_URLHANDLER_DECLSPEC [[deprecated(
+                "Use view::execute")]] extern const view &response_501;
         /// Used to return a standard 503 (service unavailable) to the user
-        FOST_URLHANDLER_DECLSPEC
-        extern const view &response_503;
+        FOST_URLHANDLER_DECLSPEC [[deprecated(
+                "Use view::execute")]] extern const view &response_503;
 
 
         /// ## Serving files
 
         /// Returns static files
-        FOST_URLHANDLER_DECLSPEC
-        extern const view &static_server;
+        FOST_URLHANDLER_DECLSPEC [[deprecated(
+                "Use view::execute")]] extern const view &static_server;
 
 
     }


### PR DESCRIPTION
Add `fost.middleware.request` that can configure to replace text in response.