### PR TITLE
Parse errors result in 400 response

### DIFF
--- a/Cpp/fost-urlhandler/control.exception.cpp
+++ b/Cpp/fost-urlhandler/control.exception.cpp
@@ -14,8 +14,8 @@
 namespace {
 
 
-    const fostlib::module c_catch{fostlib::c_fost_web_urlhandler,
-                                  "control.exception.catch"};
+    const fostlib::module c_catch{
+            fostlib::c_fost_web_urlhandler, "control.exception.catch"};
 
 
     const class catch_exception final : public fostlib::urlhandler::view {

--- a/Cpp/fost-urlhandler/middleware.replace.tests.cpp
+++ b/Cpp/fost-urlhandler/middleware.replace.tests.cpp
@@ -42,9 +42,9 @@ FSL_TEST_FUNCTION(simple) {
 
 
 FSL_TEST_FUNCTION(setting) {
-    fostlib::setting<fostlib::string> const s{"middleware.replace.tests.cpp",
-                                              "Test middleware", "Replacement",
-                                              "Very OK", true};
+    fostlib::setting<fostlib::string> const s{
+            "middleware.replace.tests.cpp", "Test middleware", "Replacement",
+            "Very OK", true};
     fostlib::json config;
     fostlib::insert(config, "view", "fost.middleware.replace");
     fostlib::insert(config, "configuration", "view", "fost.response.200");

--- a/Cpp/fost-urlhandler/responses.file.cpp
+++ b/Cpp/fost-urlhandler/responses.file.cpp
@@ -56,8 +56,8 @@ std::pair<boost::shared_ptr<fostlib::mime>, int> fostlib::urlhandler::serve_file
     fostlib::mime::mime_headers headers;
     auto now = fostlib::timestamp::now();
     headers.set("Date", timestamp_to_string(now));
-    static const fostlib::jcursor expires_path{"response", "headers",
-                                               "expires"};
+    static const fostlib::jcursor expires_path{
+            "response", "headers", "expires"};
     if (configuration.has_key(expires_path)) {
         auto expire_duration =
                 fostlib::coerce<fostlib::timediff>(configuration[expires_path]);

--- a/Cpp/fost-urlhandler/responses.proxy.cpp
+++ b/Cpp/fost-urlhandler/responses.proxy.cpp
@@ -111,8 +111,8 @@ fostlib::http::user_agent::request fostlib::web_proxy::base::ua_request(
         string const &path,
         http::server::request &request,
         host const &host) const {
-    return http::user_agent::request{request.method(), std::move(location),
-                                     request.data()};
+    return http::user_agent::request{
+            request.method(), std::move(location), request.data()};
 }
 
 

--- a/Cpp/fost-urlhandler/responses.static.tests.cpp
+++ b/Cpp/fost-urlhandler/responses.static.tests.cpp
@@ -39,8 +39,9 @@ namespace {
     fostlib::string content(const fostlib::mime &body) {
         fostlib::string text;
         for (auto part : body) {
-            text += std::string{reinterpret_cast<char const *>(part.first),
-                                reinterpret_cast<char const *>(part.second)};
+            text += std::string{
+                    reinterpret_cast<char const *>(part.first),
+                    reinterpret_cast<char const *>(part.second)};
         }
         return text;
     }

--- a/Cpp/fost-urlhandler/responses.tests.cpp
+++ b/Cpp/fost-urlhandler/responses.tests.cpp
@@ -17,8 +17,9 @@ namespace {
     fostlib::string content(const fostlib::mime &body) {
         fostlib::string text;
         for (auto part : body) {
-            text += std::string{reinterpret_cast<char const *>(part.first),
-                                reinterpret_cast<char const *>(part.second)};
+            text += std::string{
+                    reinterpret_cast<char const *>(part.first),
+                    reinterpret_cast<char const *>(part.second)};
         }
         return text;
     }

--- a/Cpp/fost-urlhandler/routing-tests.cpp
+++ b/Cpp/fost-urlhandler/routing-tests.cpp
@@ -78,9 +78,9 @@ FSL_TEST_FUNCTION(dotdotslash_not_allowed) {
 
 FSL_TEST_FUNCTION(fostlib_exception_is_500) {
     fostlib::json configuration;
-    fostlib::insert(configuration, "view", "test.throw");
+    fostlib::insert(configuration, "", "view", "test.throw");
     fostlib::insert(
-            configuration, "configuration", "exception",
+            configuration, "", "configuration", "exception",
             "fostlib::exceptions::null");
     const fostlib::setting<fostlib::json> host_config{
             "urlhandling/routing-tests.cpp/fostlib_exception_is_500",
@@ -89,6 +89,24 @@ FSL_TEST_FUNCTION(fostlib_exception_is_500) {
             "GET", "/", std::make_unique<fostlib::binary_body>(),
             [](auto const &, auto const &message) {
                 FSL_CHECK_EQ(message, "500 Internal Server Error");
+            }};
+    FSL_CHECK(fostlib::urlhandler::service(req));
+}
+
+
+FSL_TEST_FUNCTION(fostlib_parse_error_is_400) {
+    fostlib::json configuration;
+    fostlib::insert(configuration, "", "view", "test.throw");
+    fostlib::insert(
+            configuration, "", "configuration", "exception",
+            "fostlib::exceptions::parse_error");
+    const fostlib::setting<fostlib::json> host_config{
+            "urlhandling/routing-tests.cpp/fostlib_parse_error_is_400",
+            "webserver", "hosts", configuration};
+    fostlib::http::server::request req{
+            "GET", "/", std::make_unique<fostlib::binary_body>(),
+            [](auto const &, auto const &message) {
+                FSL_CHECK_EQ(message, "400 Bad Request");
             }};
     FSL_CHECK(fostlib::urlhandler::service(req));
 }

--- a/Cpp/fost-urlhandler/routing-tests.cpp
+++ b/Cpp/fost-urlhandler/routing-tests.cpp
@@ -1,5 +1,5 @@
 /**
-    Copyright 2011-2019 Red Anchor Trading Co. Ltd.
+    Copyright 2011-2020 Red Anchor Trading Co. Ltd.
 
     Distributed under the Boost Software License, Version 1.0.
     See <http://www.boost.org/LICENSE_1_0.txt>
@@ -40,8 +40,8 @@ FSL_TEST_FUNCTION(has_configuration) {
     fostlib::json configuration;
     fostlib::insert(configuration, "", "fost.response.404");
     const fostlib::setting<fostlib::json> host_config(
-            "urlhandling/routing-tests.cpp", "webserver", "hosts",
-            configuration);
+            "urlhandling/routing-tests.cpp/has_configuration", "webserver",
+            "hosts", configuration);
 
     fostlib::http::server::request req(
             "GET", "/", std::make_unique<fostlib::binary_body>(),
@@ -72,5 +72,23 @@ FSL_TEST_FUNCTION(dotdotslash_not_allowed) {
     fostlib::http::server::request req(
             "GET", "../", std::make_unique<fostlib::binary_body>(),
             directory_error);
+    FSL_CHECK(fostlib::urlhandler::service(req));
+}
+
+
+FSL_TEST_FUNCTION(fostlib_exception_is_500) {
+    fostlib::json configuration;
+    fostlib::insert(configuration, "view", "test.throw");
+    fostlib::insert(
+            configuration, "configuration", "exception",
+            "fostlib::exceptions::null");
+    const fostlib::setting<fostlib::json> host_config{
+            "urlhandling/routing-tests.cpp/fostlib_exception_is_500",
+            "webserver", "hosts", configuration};
+    fostlib::http::server::request req{
+            "GET", "/", std::make_unique<fostlib::binary_body>(),
+            [](auto const &, auto const &message) {
+                FSL_CHECK_EQ(message, "500 Internal Server Error");
+            }};
     FSL_CHECK(fostlib::urlhandler::service(req));
 }

--- a/Cpp/fost-urlhandler/test.throw.cpp
+++ b/Cpp/fost-urlhandler/test.throw.cpp
@@ -23,6 +23,10 @@ namespace {
         map->emplace_if_not_found("std::logic_error", [](fostlib::string msg) {
             throw std::logic_error{static_cast<std::string>(msg)};
         });
+        map->emplace_if_not_found(
+                "fostlib::exceptions::null", [](fostlib::string msg) {
+                    throw fostlib::exceptions::null{msg};
+                });
         return map;
     }();
 

--- a/Cpp/fost-urlhandler/test.throw.cpp
+++ b/Cpp/fost-urlhandler/test.throw.cpp
@@ -1,5 +1,5 @@
 /**
-    Copyright 2019 Red Anchor Trading Co. Ltd.
+    Copyright 2019-2020 Red Anchor Trading Co. Ltd.
 
     Distributed under the Boost Software License, Version 1.0.
     See <http://www.boost.org/LICENSE_1_0.txt>
@@ -7,9 +7,11 @@
 
 
 #include "fost-urlhandler.hpp"
+#include <f5/threading/map.hpp>
 #include <fost/test-throw-view.hpp>
 #include <fost/urlhandler.hpp>
-#include <f5/threading/map.hpp>
+
+#include <fost/exception/parse_error.hpp>
 
 #include <stdexcept>
 
@@ -26,6 +28,10 @@ namespace {
         map->emplace_if_not_found(
                 "fostlib::exceptions::null", [](fostlib::string msg) {
                     throw fostlib::exceptions::null{msg};
+                });
+        map->emplace_if_not_found(
+                "fostlib::exceptions::parse_error", [](fostlib::string msg) {
+                    throw fostlib::exceptions::parse_error{msg};
                 });
         return map;
     }();

--- a/Cpp/fost-webserver/webserver.cpp
+++ b/Cpp/fost-webserver/webserver.cpp
@@ -14,27 +14,25 @@
 #include <fost/urlhandler>
 
 
-using namespace fostlib;
-
-
 namespace {
-    const setting<string>
+    const fostlib::setting<fostlib::string>
             c_cwd("webserver.cpp", "webserver", "Change directory", "");
-    const setting<string>
+    const fostlib::setting<fostlib::string>
             c_host("webserver.cpp", "webserver", "Bind to", "localhost");
-    const setting<int> c_port("webserver.cpp", "webserver", "Port", 8001);
-    const setting<string>
+    const fostlib::setting<int>
+            c_port("webserver.cpp", "webserver", "Port", 8001);
+    const fostlib::setting<fostlib::string>
             c_mime("webserver.cpp",
                    "webserver",
                    "MIME types",
                    "Configuration/mime-types.json");
-    const setting<json>
-            c_load("webserver.cpp", "webserver", "Load", json::array_t());
+    const fostlib::setting<fostlib::json> c_load(
+            "webserver.cpp", "webserver", "Load", fostlib::json::array_t());
 
-    const setting<json> c_logger(
+    const fostlib::setting<fostlib::json> c_logger(
             "webserver.cpp", "webserver", "logging", fostlib::json(), true);
     // Take out the Fost logger configuration so we don't end up with both
-    const setting<json> c_fost_logger(
+    const fostlib::setting<fostlib::json> c_fost_logger(
             "webserver.cpp",
             "webserver",
             "Logging sinks",
@@ -55,7 +53,7 @@ FSL_MAIN(
     std::vector<fostlib::settings> configuration;
     configuration.reserve(args.size());
     for (std::size_t arg{1}; arg != args.size(); ++arg) {
-        o << "Loading config " << json(args[arg].value());
+        o << "Loading config " << fostlib::json(args[arg].value());
         auto filename = fostlib::coerce<fostlib::fs::path>(args[arg].value());
         configuration.emplace_back(std::move(filename));
     }
@@ -82,16 +80,15 @@ FSL_MAIN(
     }
 
     // Load MIME types
-    urlhandler::load_mime_configuration(c_mime.value());
+    fostlib::urlhandler::load_mime_configuration(c_mime.value());
 
     // Bind server to host and port
-    http::server server(host(c_host.value()), c_port.value());
-    o << L"Answering requests on "
-         L"http://"
-      << server.binding() << L":" << server.port() << L"/" << std::endl;
+    fostlib::http::server server(fostlib::host(c_host.value()), c_port.value());
+    o << "Answering requests on http://" << server.binding() << ":"
+      << server.port() << "/" << std::endl;
 
     // Service requests
-    server(urlhandler::service);
+    server(fostlib::urlhandler::service);
 
     // It will never get this far
     return 0;


### PR DESCRIPTION
Changes the HTTP service to explicitly capture `parse_error` exceptions and turn them into 400 responses.